### PR TITLE
issue/78: Set date to ISO format and make time more readable

### DIFF
--- a/etc-overlay/opennms.properties.d/time-format.properties
+++ b/etc-overlay/opennms.properties.d/time-format.properties
@@ -1,0 +1,1 @@
+org.opennms.ui.datettimeformat=yyyy-MM-dd HH:mm:ss z


### PR DESCRIPTION
The date and time is now shown as: 2019-02-15 14:10:09 CET

Resolves: #78 